### PR TITLE
Update icp_advance_api.cpp

### DIFF
--- a/examples/icp_advance_api.cpp
+++ b/examples/icp_advance_api.cpp
@@ -49,7 +49,7 @@ using namespace PointMatcherSupport;
 typedef PointMatcher<float> PM;
 typedef PM::DataPoints DP;
 typedef PM::Parameters Parameters;
-typedef PointMatcherSupport::CurrentBibliography CurrentBibliography;
+typedef PointMatcherSupport::CurrentBibliography Currentbibliography;
 
 void listModules();
 int validateArgs(const int argc, const char *argv[],
@@ -267,7 +267,7 @@ int main(int argc, const char *argv[])
 // The following code allows to dump all existing modules
 template<typename R>
 void dumpRegistrar(const PM& pm, const R& registrar, const std::string& name,
-				   CurrentBibliography& bib)
+				   Currentbibliography& bib)
 {
 	cout << "* " << name << " *\n" << endl;
 	for (BOOST_AUTO(it, registrar.begin()); it != registrar.end(); ++it)
@@ -284,7 +284,7 @@ void dumpRegistrar(const PM& pm, const R& registrar, const std::string& name,
 
 void listModules()
 {
-	CurrentBibliography bib;
+	Currentbibliography bib;
 
 	DUMP_REGISTRAR_CONTENT(PM::get(), Transformation, bib)
 			DUMP_REGISTRAR_CONTENT(PM::get(), DataPointsFilter, bib)


### PR DESCRIPTION
Bug: 'CurrentBibliography' : ambiguous symbol. Replaced typedef PointMatcherSupport::CurrentBibliography typedef with Currentbibliography and its usage. Probably compiler is confusing which symbol to refer.
